### PR TITLE
use str

### DIFF
--- a/benches/rpc.rs
+++ b/benches/rpc.rs
@@ -242,7 +242,7 @@ pub fn benchmark_get_block_numbers(c: &mut Criterion) {
     
     let rpc = HyperRpcClient::new(
         TransportBuilder::new(
-            "https://mainnet.infura.io/v3/1f2bd7408b1542e89bd4274b688aa6a4".to_string(),
+            "https://mainnet.infura.io/v3/1f2bd7408b1542e89bd4274b688aa6a4",
         )
         .build_http_hyper(),
     );

--- a/src/hyper_rpc.rs
+++ b/src/hyper_rpc.rs
@@ -621,7 +621,7 @@ mod tests {
 
         let client = RpcClient::new(
             TransportBuilder::new(
-                "https://mainnet.infura.io/v3/2DCsBRUv8lDFmznC1BGik1pFKAL".to_string(),
+                "https://mainnet.infura.io/v3/2DCsBRUv8lDFmznC1BGik1pFKAL",
             )
             .build_http_hyper(),
         );
@@ -644,7 +644,7 @@ mod tests {
     async fn test_get_block() {
         let rpc = RpcClient::new(
             TransportBuilder::new(
-                "https://mainnet.infura.io/v3/1f2bd7408b1542e89bd4274b688aa6a4".to_string(),
+                "https://mainnet.infura.io/v3/1f2bd7408b1542e89bd4274b688aa6a4",
             )
             .build_http_hyper(),
         );

--- a/src/hyper_transport.rs
+++ b/src/hyper_transport.rs
@@ -22,11 +22,11 @@ pub struct HyperTransport {
         HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>,
         http_body_util::Full<::hyper::body::Bytes>,
     >,
-    url: String,
+    url:  &'static str,
 }
 
 impl HyperTransport {
-    pub fn new(url: String) -> Self {
+    pub fn new(url:  &'static str) -> Self {
         debug!("Creating new HyperTransport for URL: {}", url);
 
         let http_executor = TokioExecutor::new();
@@ -64,13 +64,13 @@ impl HyperTransport {
 #[async_trait]
 impl Transport for HyperTransport {
     async fn hyper_execute(&self, request: String) -> Result<String, RpcError> {
-        let url = &self.url;
+        let url = self.url;
 
         let reqs = request.as_bytes().to_owned().into();
 
         let req = hyper::Request::builder()
             .method(hyper::Method::POST)
-            .uri(url.as_str())
+            .uri(url)
             .header("Content-Type", CONTENT_TYPE_JSON)
             .body(http_body_util::Full::new(reqs))
             .expect("Failed to build request");
@@ -93,13 +93,13 @@ impl Transport for HyperTransport {
     }
 
     async fn hyper_execute_raw(&self, request: Vec<u8>) -> Result<Vec<u8>, RpcError> {
-        let url = &self.url;
+        let url = self.url;
 
         let reqs = Bytes::from(request);
 
         let req = hyper::Request::builder()
             .method(hyper::Method::POST)
-            .uri(url.as_str())
+            .uri(url)
             .header("Content-Type", CONTENT_TYPE_JSON)
             .body(http_body_util::Full::new(reqs))
             .expect("Failed to build request");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use reqwest::Client;
 use std::time::Duration;
 
@@ -6,13 +5,13 @@ pub mod transport;
 pub mod parser;
 pub mod hyper_transport;
 pub mod hyper_rpc;
-use dotenv;
-use std::env;
+
+
 
 #[derive(Debug)]
 pub struct HttpTransport {
     client: Client,
-    urls: Vec<String>,
+    urls:  &'static str,
     current_url: usize,
     timeout: Duration,
 }
@@ -28,7 +27,7 @@ pub enum RpcError {
 }
 
 impl HttpTransport {
-    pub fn new(url: String) -> Self {
+    pub fn new(url: &'static str) -> Self {
         let client = Client::builder()
             .timeout(Duration::from_secs(30))
             .pool_idle_timeout(Duration::from_secs(60))
@@ -38,48 +37,10 @@ impl HttpTransport {
 
         Self {
             client,
-            urls: vec![url],
+            urls: url,
             current_url: 0,
             timeout: Duration::from_secs(30),
         }
-    }
-
-    pub fn new_from_env() -> Self {
-        dotenv::dotenv().ok();
-
-        let primary_url = env::var("PRIMARY_URL").expect("PRIMARY_URL must be set in environment");
-
-        let mut urls = vec![primary_url];
-        if let Ok(fallback1) = env::var("FALLBACK_URL_1") {
-            urls.push(fallback1);
-        }
-        if let Ok(fallback2) = env::var("FALLBACK_URL_2") {
-            urls.push(fallback2);
-        }
-
-        let transport_timeout = env::var("TRANSPORT_TIMEOUT")
-            .unwrap_or_else(|_| "30".to_string())
-            .parse()
-            .unwrap_or(30);
-
-        let client = Client::builder()
-            .timeout(Duration::from_secs(transport_timeout))
-            .pool_idle_timeout(Duration::from_secs(60))
-            .tcp_keepalive(Duration::from_secs(60))
-            .build()
-            .expect("Failed to create HTTP client");
-
-        Self {
-            client,
-            urls,
-            current_url: 0,
-            timeout: Duration::from_secs(transport_timeout),
-        }
-    }
-
-    pub fn with_fallback_urls(mut self, urls: Vec<String>) -> Self {
-        self.urls.extend(urls);
-        self
     }
 
     pub fn new_with_config(self) -> Self {

--- a/src/transport/http.rs
+++ b/src/transport/http.rs
@@ -10,14 +10,14 @@ pub trait Transport: Send + Sync + std::fmt::Debug {
 }
 
 pub struct TransportBuilder {
-    url: String,
+    url:  &'static str,
     timeout: Duration,
     max_retries: u32,
     pool_max_idle: u32,
 }
 
 impl TransportBuilder {
-    pub fn new(url: String) -> Self {
+    pub fn new(url:  &'static str) -> Self {
         Self {
             url,
             timeout: Duration::from_secs(10),


### PR DESCRIPTION
use str

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified handling of URLs across the application by changing several fields and constructor methods to use static string slices (`&'static str`) instead of owned strings or vectors.
  * Removed unused methods and imports related to environment variable handling and fallback URLs.
  * Streamlined test and benchmark code to align with the updated URL handling approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->