### PR TITLE
Fix parsing of removed flag in log parser

### DIFF
--- a/src/parser/lib.rs
+++ b/src/parser/lib.rs
@@ -3,9 +3,9 @@ use alloy::primitives::{Address, B256, U256, U64};
 #[inline]
 pub fn unsafe_hex_to_address(hex: &[u8]) -> Address {
     let mut bytes = [0u8; 20];
-  
+
     // Skip 0x
-    let hex_ptr = unsafe {hex.as_ptr().add(2)};
+    let hex_ptr = unsafe { hex.as_ptr().add(2) };
     let out_ptr = bytes.as_mut_ptr();
 
     unsafe {
@@ -15,14 +15,14 @@ pub fn unsafe_hex_to_address(hex: &[u8]) -> Address {
                 b @ b'0'..=b'9' => b - b'0',
                 b @ b'a'..=b'f' => b - b'a' + 10,
                 b @ b'A'..=b'F' => b - b'A' + 10,
-                _ => 0, 
+                _ => 0,
             };
 
             let low = match *hex_ptr.add(sum + 1) {
                 b @ b'0'..=b'9' => b - b'0',
                 b @ b'a'..=b'f' => b - b'a' + 10,
                 b @ b'A'..=b'F' => b - b'A' + 10,
-                _ => 0, 
+                _ => 0,
             };
 
             *out_ptr.add(i) = (high << 4) | low;
@@ -35,7 +35,6 @@ pub fn unsafe_hex_to_address(hex: &[u8]) -> Address {
 #[inline]
 pub fn unsafe_hex_to_b256(hex: &[u8]) -> B256 {
     let mut bytes = [0u8; 32];
-
 
     let hex_ptr = hex.as_ptr();
     let out_ptr = bytes.as_mut_ptr();
@@ -162,5 +161,16 @@ pub fn find_field(data: &[u8], prefix: &[u8], suffix: &[u8]) -> Option<(usize, u
     let start = memchr::memmem::find(data, prefix)?;
     let start = start + prefix.len();
     let end = start + memchr::memmem::find(&data[start..], suffix)?;
+    Some((start, end))
+}
+
+#[inline]
+pub fn find_bool_field(data: &[u8], prefix: &[u8]) -> Option<(usize, usize)> {
+    let start = memchr::memmem::find(data, prefix)? + prefix.len();
+    let end = if data.get(start)? == &b't' {
+        start + 4
+    } else {
+        start + 5
+    };
     Some((start, end))
 }


### PR DESCRIPTION
## Summary
- parse the `removed` flag for log entries
- add helper `find_bool_field` for boolean fields
- add unit test for log `removed` parsing

## Testing
- `cargo test parses_removed_field`
- `cargo test` *(fails: Request failed: client error (Connect))*

------
https://chatgpt.com/codex/tasks/task_e_6894cac502d88332bfcac7604858c44c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for parsing and exposing the "removed" boolean field in log entries.

* **Bug Fixes**
  * Ensured the "removed" field in logs accurately reflects the value from input data.

* **Tests**
  * Introduced a unit test to verify correct parsing and handling of the "removed" field in logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->